### PR TITLE
Specify ".NET Framework"

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ Excel-DNA is an independent project to integrate .NET into Excel. With Excel-DNA
 ## Getting Started
 If you are using a version of Visual Studio that supports the [NuGet Package Manager][nuget] (including Visual Studio 2012 Express for Windows Desktop or any more recent Visual Studio version), the easiest way to make an Excel-DNA add-in is to:
 
-1. Create a new **Class Library** project in Visual Basic, C# or F#;
+1. Create a new **Class Library (.NET Framework)** project in Visual Basic, C# or F#;
 
 2. Use the **Manage NuGet Packages** dialog or the **Package Manager Console** to install the **Excel-DNA** package:
 {% highlight powershell %}


### PR DESCRIPTION
ExcelDNA won't install correctly if a user selects "Class Library (.NET Standard)" which appears second in the list in the "New Project" dialog (at least in Visual Studio 2019).

As per [a previous thread](https://groups.google.com/d/msg/exceldna/qNXRhCwpuzg/erFYaeFqAgAJ), the project must use .NET Framework.

Having just upgraded to Visual Studio 2019, when starting a new ExcelDNA project, I ran into issues because this wasn't specified.